### PR TITLE
Add BGG API key support and Docker deployment scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,4 +363,5 @@ MigrationBackup/
 FodyWeavers.xsd
 
 appsettings.json
+NewToken.txt
 *.tar

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Restore, build, test, run
+dotnet restore
+dotnet build
+dotnet test
+dotnet run --project DiscordBGGCollection/DiscordBGGCollection.csproj
+
+# Run a single test by name
+dotnet test --filter "FullyQualifiedName~FetchGamesFromBGG"
+
+# Docker
+docker build -t discordbggcollection .
+docker run -d --name discordbggcollection \
+  -v /path/to/appsettings.json:/app/appsettings.json \
+  -e DOTNET_ENVIRONMENT=Production \
+  discordbggcollection
+```
+
+## Configuration
+
+`appsettings.json` is gitignored and must be created locally. See `appsettings.example.json` for the required shape:
+```json
+{
+  "BotToken": "<discord-bot-token>",
+  "BggApiKey": "<bgg-application-token>"
+}
+```
+
+`BggApiKey` is sent as `Authorization: Bearer <key>` on every BGG XML API v2 request. Register an application at https://boardgamegeek.com/applications to obtain a token.
+
+It is also excluded from the Docker image via `.dockerignore` and must be mounted as a volume at runtime — never baked into the image.
+
+## Architecture
+
+**Two projects:**
+- `DiscordBGGCollection/` — the bot application
+- `TestCases/` — xUnit tests (currently hit the real BGG API, not mocked)
+
+**Flow:**
+1. `Program.cs` initializes `DiscordSocketClient`, registers `CommandService`, wires up DI (`HttpClient`, `BGGCommands`, `IConfiguration`), and sets the `MessageReceived` handler.
+2. `MessageReceived` strips the `/` prefix, maps bare `/bgg` and unknown subcommands to `help`, then executes via `CommandService`.
+3. `BGGCommands.cs` (`ModuleBase<SocketCommandContext>`, group `"bgg"`) contains all command logic. It calls the BGG XML API v2 (`https://boardgamegeek.com/xmlapi2/collection`), parses XML with `XDocument`/LINQ-to-XML, and formats tabular responses.
+4. Responses over 2000 characters are sent as attached text files via a direct HTTP POST to the Discord API (`SendFileManuallyAsync`).
+
+**Resilience:** BGG frequently returns HTTP 202 (queue/processing). BGGCommands handles this with a manual retry loop in addition to a Polly `AsyncRetryPolicy` with exponential backoff for `HttpRequestException` and `TaskCanceledException`.
+
+**Key dependencies:** Discord.Net 3.4.0, Polly 8.5.0, xUnit, coverlet.
+
+## Incomplete / Stub Features
+
+- `/bgg plays <username>` — command exists but is not implemented.

--- a/DiscordBGGCollection/BGGCommands.cs
+++ b/DiscordBGGCollection/BGGCommands.cs
@@ -35,6 +35,13 @@ namespace DiscordBGGCollection
             _httpClient = httpClient;
             _configuration = configuration;
 
+            var bggApiKey = configuration["BggApiKey"];
+            if (!string.IsNullOrEmpty(bggApiKey))
+            {
+                _httpClient.DefaultRequestHeaders.Authorization =
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", bggApiKey);
+            }
+
             _retryPolicy = Policy
                 .Handle<HttpRequestException>()
                 .Or<TaskCanceledException>()
@@ -78,7 +85,7 @@ namespace DiscordBGGCollection
             int i = 1;
             foreach (var game in games)
             {
-                var year = game.YearPublished == 0 ? "—" : game.YearPublished.ToString();
+                var year = game.YearPublished == 0 ? "ï¿½" : game.YearPublished.ToString();
                 var name = game.Name?.Length > 40 ? game.Name.Substring(0, 37) + "..." : game.Name;
 
                 lines.Add(string.Format("{0,-4} {1,-40} {2,-6} {3,-5}",

--- a/DiscordBGGCollection/appsettings.example.json
+++ b/DiscordBGGCollection/appsettings.example.json
@@ -1,0 +1,4 @@
+{
+  "BotToken": "<your-discord-bot-token>",
+  "BggApiKey": "<your-bgg-application-token>"
+}

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,24 @@
+# Future Work
+
+## Correctness / Reliability
+
+1. **Implement `/bgg plays`** — the command exists but returns nothing. Implement it or remove it.
+2. **Mock HTTP in tests** — current tests hit the real BGG API and are flaky offline. Add mocked `HttpClient` tests that don't depend on live BGG user data.
+
+## Architecture
+
+3. **Extract `BggApiClient`** — HTTP calls, XML parsing, and retry logic are all in `BGGCommands.cs`. Move them into a dedicated client class.
+4. **Extract `ResponseFormatter`** — table formatting and file-upload logic should live separately from command handlers.
+5. **Replace `SendFileManuallyAsync` with Discord.Net's `SendFileAsync`** — removes the raw HTTP POST and ~30 lines of manual auth handling.
+6. **Use typed options** — replace `_config["BotToken"]` magic strings with an `IOptions<BotSettings>` class.
+
+## Features
+
+7. **Reverse `/bgg compare` direction** — currently only checks user1's want-to-play vs user2's collection. Support the reverse.
+8. **Response caching** — cache BGG API responses for 5–10 minutes to reduce latency and API load.
+9. **Pagination** — large collections are truncated. Add pagination instead of cutting off results.
+
+## Ops
+
+10. **Structured logging** — replace `Console.WriteLine` with `Microsoft.Extensions.Logging` for better Docker log aggregation.
+11. **Wire up `DOTNET_ENVIRONMENT`** — the Docker run command sets it to `Production` but the app doesn't load `appsettings.Production.json`. Implement environment-specific config or remove the env var.

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,32 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Destination  # e.g. jason@ssh.tendimensions.com
+)
+
+$RemoteDir = "~/discordbggcollection"
+$TempDir = Join-Path $env:TEMP "discordbggcollection-deploy"
+
+Write-Host "Staging files to $TempDir..."
+
+# Clean and recreate temp staging dir
+if (Test-Path $TempDir) { Remove-Item -Recurse -Force $TempDir }
+New-Item -ItemType Directory -Path $TempDir | Out-Null
+
+# Copy source, excluding build artifacts and secrets
+$ExcludeDirs = @("bin", "obj", ".vs", ".git")
+robocopy "." $TempDir /E /XD $ExcludeDirs /XF "appsettings.json" "NewToken.txt" "*.user" | Out-Null
+
+Write-Host "Copying to ${Destination}:${RemoteDir}..."
+ssh $Destination "mkdir -p $RemoteDir"
+scp -r "$TempDir\*" "${Destination}:${RemoteDir}/"
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "scp failed. Aborting."
+    exit 1
+}
+
+Write-Host "Cleaning up staging dir..."
+Remove-Item -Recurse -Force $TempDir
+
+Write-Host "Running deploy script on remote..."
+ssh $Destination "sed -i 's/\r//' $RemoteDir/deploy.sh && bash $RemoteDir/deploy.sh"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+CONTAINER_NAME="discordbggcollection"
+IMAGE_NAME="discordbggcollection"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APPSETTINGS_PATH="$SCRIPT_DIR/appsettings.json"
+
+if [ ! -f "$APPSETTINGS_PATH" ]; then
+    echo "ERROR: $APPSETTINGS_PATH not found. Place your appsettings.json in your home directory before deploying."
+    exit 1
+fi
+
+echo "Building Docker image..."
+docker build -t "$IMAGE_NAME" "$SCRIPT_DIR"
+
+echo "Stopping existing container (if running)..."
+docker stop "$CONTAINER_NAME" 2>/dev/null || true
+docker rm "$CONTAINER_NAME" 2>/dev/null || true
+
+echo "Starting container..."
+docker run -d \
+    --name "$CONTAINER_NAME" \
+    --restart unless-stopped \
+    -v "$APPSETTINGS_PATH:/app/appsettings.json:ro" \
+    -e DOTNET_ENVIRONMENT=Production \
+    "$IMAGE_NAME"
+
+echo "Done. Container status:"
+docker ps --filter "name=$CONTAINER_NAME"


### PR DESCRIPTION
## Summary
- Adds BGG API key support — read from `appsettings.json` and sent as `Authorization: Bearer` header on all BGG XML API v2 requests
- Adds `deploy.ps1` (Windows) and `deploy.sh` (remote) for SCP-based Docker deployment; `appsettings.json` is mounted on the remote and never copied by the deploy
- Adds `appsettings.example.json` as a safe-to-commit config template
- Adds `NewToken.txt` to `.gitignore`
- Adds `CLAUDE.md` with architecture notes and build/run commands
- Adds `IMPROVEMENTS.md` tracking future work

## Test plan
- [ ] Confirm `appsettings.example.json` contains no real secrets
- [ ] Run `.\deploy.ps1 -Destination <host>` and verify container starts successfully
- [ ] Test `/bgg games <username>` in Discord to confirm BGG API key is accepted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)